### PR TITLE
feat(text-diff-editor): close button, recent files, independent panel mode

### DIFF
--- a/text-diff-editor/index.html
+++ b/text-diff-editor/index.html
@@ -319,6 +319,99 @@
       letter-spacing: 0.02em;
     }
 
+    /* Open + Recent group */
+    .toolbar-open-group {
+      display: flex;
+      align-items: center;
+      position: relative;
+    }
+
+    .toolbar-recent-arrow {
+      min-width: 24px !important;
+      padding: 0 2px !important;
+    }
+
+    .toolbar-chevron {
+      font-size: 12px;
+      opacity: 0.7;
+    }
+
+    .recent-dropdown {
+      position: absolute;
+      top: 100%;
+      left: 0;
+      margin-top: var(--space-xs);
+      min-width: 260px;
+      max-height: 360px;
+      overflow-y: auto;
+      background: var(--bg-toast);
+      border: 1px solid var(--border-primary);
+      border-radius: var(--radius-md);
+      box-shadow: var(--shadow-lg);
+      padding: var(--space-xs);
+      z-index: 200;
+    }
+
+    .recent-dropdown[hidden] {
+      display: none;
+    }
+
+    .recent-item {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      width: 100%;
+      border: none;
+      background: transparent;
+      color: var(--text-primary);
+      font-family: var(--font-ui);
+      font-size: var(--font-size-sm);
+      padding: var(--space-sm) var(--space-md);
+      border-radius: var(--radius-sm);
+      cursor: pointer;
+      text-align: left;
+      gap: var(--space-sm);
+      transition: background var(--transition-fast);
+    }
+
+    .recent-item:hover {
+      background: var(--bg-hover);
+    }
+
+    .recent-item-name {
+      flex: 1;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      font-family: var(--font-mono);
+      font-size: var(--font-size-xs);
+    }
+
+    .recent-item-time {
+      flex-shrink: 0;
+      font-size: 11px;
+      color: var(--text-tertiary);
+    }
+
+    .recent-clear {
+      color: var(--text-tertiary) !important;
+      font-size: var(--font-size-xs) !important;
+      justify-content: center !important;
+    }
+
+    .recent-divider {
+      height: 1px;
+      background: var(--border-primary);
+      margin: var(--space-xs) 0;
+    }
+
+    .recent-empty {
+      padding: var(--space-md);
+      text-align: center;
+      color: var(--text-tertiary);
+      font-size: var(--font-size-xs);
+    }
+
     /* Zoom Group */
     .toolbar-zoom-group {
       display: flex;
@@ -585,7 +678,7 @@
     .panel-header {
       display: flex;
       align-items: center;
-      justify-content: space-between;
+      gap: var(--space-sm);
       padding: var(--space-xs) var(--space-md);
       background: var(--bg-panel-header);
       border-bottom: 1px solid var(--border-subtle);
@@ -599,6 +692,41 @@
       color: var(--text-tertiary);
       text-transform: uppercase;
       letter-spacing: 0.06em;
+      flex-shrink: 0;
+    }
+
+    .panel-filename {
+      flex: 1;
+      font-size: var(--font-size-xs);
+      font-family: var(--font-mono);
+      color: var(--text-secondary);
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      min-width: 0;
+    }
+
+    .panel-close-btn {
+      flex-shrink: 0;
+      border: none;
+      background: transparent;
+      color: var(--text-tertiary);
+      font-size: 14px;
+      width: 24px;
+      height: 24px;
+      border-radius: var(--radius-sm);
+      cursor: pointer;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      transition: all var(--transition-fast);
+      opacity: 0.5;
+    }
+
+    .panel-close-btn:hover {
+      background: var(--bg-active);
+      color: var(--text-primary);
+      opacity: 1;
     }
 
     /* Editor Inner: line numbers + textarea */
@@ -1123,6 +1251,8 @@
     <div id="panel-left" class="editor-panel">
       <div class="panel-header">
         <span class="panel-title">Original</span>
+        <span class="panel-filename" id="panel-left-filename">Untitled</span>
+        <button class="panel-close-btn" data-panel="left" title="Close file" aria-label="Close file">&times;</button>
       </div>
       <div class="editor-inner">
         <div id="line-numbers-left" class="line-numbers" aria-hidden="true"></div>
@@ -1146,6 +1276,8 @@
     <div id="panel-center" class="editor-panel" hidden>
       <div class="panel-header">
         <span class="panel-title">Center</span>
+        <span class="panel-filename" id="panel-center-filename">Untitled</span>
+        <button class="panel-close-btn" data-panel="center" title="Close file" aria-label="Close file">&times;</button>
       </div>
       <div class="editor-inner">
         <div id="line-numbers-center" class="line-numbers" aria-hidden="true"></div>
@@ -1169,6 +1301,8 @@
     <div id="panel-right" class="editor-panel" hidden>
       <div class="panel-header">
         <span class="panel-title">Modified</span>
+        <span class="panel-filename" id="panel-right-filename">Untitled</span>
+        <button class="panel-close-btn" data-panel="right" title="Close file" aria-label="Close file">&times;</button>
       </div>
       <div class="editor-inner">
         <div id="line-numbers-right" class="line-numbers" aria-hidden="true"></div>
@@ -1292,12 +1426,32 @@
             break;
           }
 
+          case 'close': {
+            // Close the focused panel's file (or left by default)
+            const closePanel = document.activeElement?.closest('.editor-panel');
+            const closePanelId = closePanel?.id === 'panel-right' ? 'right'
+              : closePanel?.id === 'panel-center' ? 'center' : 'left';
+            const editor = closePanelId === 'right' ? editorRight
+              : closePanelId === 'center' ? editorCenter : editorLeft;
+
+            if (editor.modified) {
+              if (!confirm('Unsaved changes will be lost. Close without saving?')) break;
+            }
+            fileManager.closeFile(closePanelId);
+            editor.setText('');
+            editor.clearModified();
+            editor.fileName = 'Untitled';
+            editor.fileHandle = null;
+            break;
+          }
+
           case 'split':
             splitView.toggle();
             break;
 
           case 'sync-scroll':
             splitView.setSyncScroll(data.params.enabled);
+            zoomController.setSyncZoom(data.params.enabled);
             break;
 
           case 'theme-toggle':
@@ -1336,22 +1490,60 @@
       // EventBus Wiring: File Operations
       // ============================================================
       EventBus.on('file:open', (data) => {
+        const editor = data.panelId === 'right' ? editorRight
+          : data.panelId === 'center' ? editorCenter : editorLeft;
+        editor.setText(data.content);
+        editor.clearModified();
+        editor.fileName = data.name;
+        editor.fileHandle = data.handle;
+
+        // Update panel header filename
+        const fnEl = document.getElementById(`panel-${data.panelId}-filename`);
+        if (fnEl) fnEl.textContent = data.name;
+      });
+
+      EventBus.on('file:close', (data) => {
+        const fnEl = document.getElementById(`panel-${data.panelId}-filename`);
+        if (fnEl) fnEl.textContent = 'Untitled';
         if (data.panelId === 'left') {
-          editorLeft.setText(data.content);
-          editorLeft.clearModified();
-          editorLeft.fileName = data.name;
-          editorLeft.fileHandle = data.handle;
-        } else if (data.panelId === 'center') {
-          editorCenter.setText(data.content);
-          editorCenter.clearModified();
-          editorCenter.fileName = data.name;
-          editorCenter.fileHandle = data.handle;
-        } else {
-          editorRight.setText(data.content);
-          editorRight.clearModified();
-          editorRight.fileName = data.name;
-          editorRight.fileHandle = data.handle;
+          statusBar.updateFileName('Untitled');
+          statusBar.updateModifiedIndicator(false);
         }
+      });
+
+      // ============================================================
+      // Per-panel close buttons (in panel headers)
+      // ============================================================
+      document.querySelectorAll('.panel-close-btn').forEach(btn => {
+        btn.addEventListener('click', () => {
+          const panelId = btn.dataset.panel;
+          const editor = panelId === 'right' ? editorRight
+            : panelId === 'center' ? editorCenter : editorLeft;
+
+          if (editor.modified) {
+            if (!confirm('Unsaved changes will be lost. Close without saving?')) return;
+          }
+          fileManager.closeFile(panelId);
+          editor.setText('');
+          editor.clearModified();
+          editor.fileName = 'Untitled';
+          editor.fileHandle = null;
+        });
+      });
+
+      // ============================================================
+      // EventBus Wiring: Recent Files
+      // ============================================================
+      EventBus.on('recent:open', (data) => {
+        const focusedPanel = document.activeElement?.closest('.editor-panel');
+        const panelId = focusedPanel?.id === 'panel-right' ? 'right'
+          : focusedPanel?.id === 'panel-center' ? 'center' : 'left';
+        fileManager.reopenRecent(data.name, panelId);
+      });
+
+      EventBus.on('recent:clear', () => {
+        fileManager.clearRecentFiles();
+        EventBus.emit('toast:show', { message: 'History cleared', type: 'info', duration: 2000 });
       });
 
       EventBus.on('file:new', (data) => {
@@ -1365,6 +1557,11 @@
         if (data.panelId === 'left') {
           fileManager.saveFile('left', editorLeft.getText());
         }
+      });
+
+      EventBus.on('file:saved', (data) => {
+        const fnEl = document.getElementById(`panel-${data.panelId}-filename`);
+        if (fnEl) fnEl.textContent = data.name;
       });
 
       // ============================================================
@@ -1476,6 +1673,12 @@
         if (mod && e.key === 's') {
           e.preventDefault();
           EventBus.emit('toolbar:action', { action: 'save' });
+        }
+
+        // Cmd+W: Close file
+        if (mod && e.key === 'w') {
+          e.preventDefault();
+          EventBus.emit('toolbar:action', { action: 'close' });
         }
 
         // Cmd+F: Search

--- a/text-diff-editor/js/split-diff.js
+++ b/text-diff-editor/js/split-diff.js
@@ -598,6 +598,7 @@ class SplitView {
    */
   setSyncScroll(enabled) {
     this.syncScroll = enabled;
+    EventBus.emit('sync:change', { enabled });
   }
 
   _navigateDiff(direction) {

--- a/text-diff-editor/js/ui.js
+++ b/text-diff-editor/js/ui.js
@@ -339,13 +339,23 @@ class Toolbar {
           <span class="toolbar-icon">&#x1F4C4;</span>
           <span class="toolbar-label">New</span>
         </button>
-        <button id="btn-open" class="toolbar-btn" title="Open (Cmd+O)" aria-label="Open file">
-          <span class="toolbar-icon">&#x1F4C2;</span>
-          <span class="toolbar-label">Open</span>
-        </button>
+        <div class="toolbar-open-group">
+          <button id="btn-open" class="toolbar-btn" title="Open (Cmd+O)" aria-label="Open file">
+            <span class="toolbar-icon">&#x1F4C2;</span>
+            <span class="toolbar-label">Open</span>
+          </button>
+          <button id="btn-recent" class="toolbar-btn toolbar-recent-arrow" title="Recent Files" aria-label="Recent files" aria-haspopup="true" aria-expanded="false">
+            <span class="toolbar-icon toolbar-chevron">&#x25BE;</span>
+          </button>
+          <div id="recent-dropdown" class="recent-dropdown" role="menu" aria-label="Recent files"></div>
+        </div>
         <button id="btn-save" class="toolbar-btn" title="Save (Cmd+S)" aria-label="Save file">
           <span class="toolbar-icon">&#x1F4BE;</span>
           <span class="toolbar-label">Save</span>
+        </button>
+        <button id="btn-close" class="toolbar-btn" title="Close (Cmd+W)" aria-label="Close file">
+          <span class="toolbar-icon">&#x2715;</span>
+          <span class="toolbar-label">Close</span>
         </button>
       </div>
       <div class="toolbar-separator"></div>
@@ -354,9 +364,9 @@ class Toolbar {
           <span class="toolbar-icon">&#x2B1C;</span>
           <span class="toolbar-label">Split</span>
         </button>
-        <button id="btn-sync-scroll" class="toolbar-btn active" title="Sync Scroll" aria-label="Toggle scroll sync" aria-pressed="true">
+        <button id="btn-sync-scroll" class="toolbar-btn active" title="Sync: scroll & zoom together (click to toggle)" aria-label="Toggle sync mode" aria-pressed="true">
           <span class="toolbar-icon">&#x1F517;</span>
-          <span class="toolbar-label">Sync</span>
+          <span class="toolbar-label" id="sync-label">Sync</span>
         </button>
         <button id="btn-diff-prev" class="toolbar-btn" title="Previous Diff (Shift+F7)" aria-label="Previous difference" hidden>
           <span class="toolbar-icon">&uarr;</span>
@@ -424,6 +434,13 @@ class Toolbar {
       EventBus.emit('toolbar:action', { action: 'save' });
     });
 
+    document.getElementById('btn-close')?.addEventListener('click', () => {
+      EventBus.emit('toolbar:action', { action: 'close' });
+    });
+
+    // Recent files dropdown
+    this._setupRecentDropdown();
+
     // View operations
     document.getElementById('btn-split')?.addEventListener('click', () => {
       EventBus.emit('toolbar:action', { action: 'split' });
@@ -433,6 +450,11 @@ class Toolbar {
       const btn = e.currentTarget;
       const isActive = btn.classList.toggle('active');
       btn.setAttribute('aria-pressed', isActive);
+      const label = document.getElementById('sync-label');
+      if (label) label.textContent = isActive ? 'Sync' : 'Indep';
+      btn.title = isActive
+        ? 'Sync: scroll & zoom together (click for independent)'
+        : 'Independent: each panel scrolls & zooms separately (click for sync)';
       EventBus.emit('toolbar:action', { action: 'sync-scroll', params: { enabled: isActive } });
     });
 
@@ -514,6 +536,93 @@ class Toolbar {
       if (prevBtn) prevBtn.hidden = !data.enabled;
       if (nextBtn) nextBtn.hidden = !data.enabled;
     });
+  }
+
+  /** @private Set up the recent files dropdown toggle and event wiring. */
+  _setupRecentDropdown() {
+    const btn = document.getElementById('btn-recent');
+    const dropdown = document.getElementById('recent-dropdown');
+    if (!btn || !dropdown) return;
+
+    btn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      const isOpen = !dropdown.hidden;
+      if (isOpen) {
+        dropdown.hidden = true;
+        btn.setAttribute('aria-expanded', 'false');
+      } else {
+        this._renderRecentList();
+        dropdown.hidden = false;
+        btn.setAttribute('aria-expanded', 'true');
+      }
+    });
+
+    // Close dropdown on outside click
+    document.addEventListener('click', (e) => {
+      if (!dropdown.hidden && !dropdown.contains(e.target) && e.target !== btn) {
+        dropdown.hidden = true;
+        btn.setAttribute('aria-expanded', 'false');
+      }
+    });
+
+    // Update dropdown content when recent files change
+    EventBus.on('recent:update', () => {
+      if (!dropdown.hidden) this._renderRecentList();
+    });
+  }
+
+  /** @private Render the recent files list into the dropdown. */
+  _renderRecentList() {
+    const dropdown = document.getElementById('recent-dropdown');
+    if (!dropdown) return;
+
+    const files = window.App?.fileManager?.getRecentFiles() || [];
+
+    if (files.length === 0) {
+      dropdown.innerHTML = '<div class="recent-empty">No recent files</div>';
+      return;
+    }
+
+    const items = files.map(f => {
+      const ago = f.time ? this._formatTimeAgo(f.time) : '';
+      return `<button class="recent-item" data-filename="${Utils.escapeHtml(f.name)}" role="menuitem">
+        <span class="recent-item-name">${Utils.escapeHtml(f.name)}</span>
+        ${ago ? `<span class="recent-item-time">${ago}</span>` : ''}
+      </button>`;
+    }).join('');
+
+    dropdown.innerHTML = items +
+      '<div class="recent-divider"></div>' +
+      '<button class="recent-item recent-clear" role="menuitem">Clear History</button>';
+
+    // Wire click handlers
+    dropdown.querySelectorAll('.recent-item[data-filename]').forEach(el => {
+      el.addEventListener('click', () => {
+        const name = el.dataset.filename;
+        dropdown.hidden = true;
+        document.getElementById('btn-recent')?.setAttribute('aria-expanded', 'false');
+        EventBus.emit('recent:open', { name });
+      });
+    });
+
+    dropdown.querySelector('.recent-clear')?.addEventListener('click', () => {
+      dropdown.hidden = true;
+      document.getElementById('btn-recent')?.setAttribute('aria-expanded', 'false');
+      EventBus.emit('recent:clear', {});
+    });
+  }
+
+  /**
+   * Format a timestamp as a relative time string.
+   * @param {number} time - Unix timestamp in ms.
+   * @returns {string}
+   */
+  _formatTimeAgo(time) {
+    const diff = Date.now() - time;
+    if (diff < 60000) return 'Just now';
+    if (diff < 3600000) return `${Math.floor(diff / 60000)}m ago`;
+    if (diff < 86400000) return `${Math.floor(diff / 3600000)}h ago`;
+    return `${Math.floor(diff / 86400000)}d ago`;
   }
 
   /**

--- a/text-diff-editor/js/viewport.js
+++ b/text-diff-editor/js/viewport.js
@@ -27,6 +27,10 @@ class ZoomController {
     this.animating = false;
     this.zoomTimer = null;
     this.enabled = true;
+    /** When false, Cmd+scroll zooms only the panel under the cursor. */
+    this.syncZoom = true;
+    /** Per-panel zoom levels keyed by panel id. */
+    this._panelLevels = { left: 1.0, center: 1.0, right: 1.0 };
 
     // Track Cmd key state independently (browser may not set metaKey on wheel events)
     this._cmdPressed = false;
@@ -57,10 +61,25 @@ class ZoomController {
     e.preventDefault();
 
     const delta = -e.deltaY * this.zoomStep;
+
+    // Independent zoom: only zoom the panel under the cursor
+    if (!this.syncZoom) {
+      const panel = e.target.closest?.('.editor-panel');
+      if (!panel) return;
+      const panelId = panel.id === 'panel-right' ? 'right'
+        : panel.id === 'panel-center' ? 'center' : 'left';
+      const current = this._panelLevels[panelId] || 1.0;
+      const newLevel = Utils.clamp(current + delta, this.minZoom, this.maxZoom);
+      if (Math.abs(newLevel - current) < 0.001) return;
+      this._panelLevels[panelId] = newLevel;
+      this._commitPanelZoom(panelId, newLevel);
+      this._throttledEmit({ level: newLevel, panelId });
+      return;
+    }
+
+    // Synced zoom: zoom all panels together
     const newLevel = Utils.clamp(this.level + delta, this.minZoom, this.maxZoom);
-
     if (Math.abs(newLevel - this.level) < 0.001) return;
-
     this.level = newLevel;
 
     // Real-time: CSS transform for smooth zoom via requestAnimationFrame
@@ -79,6 +98,35 @@ class ZoomController {
     this.zoomTimer = setTimeout(() => this.commitZoom(), 200);
 
     this._throttledEmit({ level: this.level, originX: ox, originY: oy });
+  }
+
+  /**
+   * Apply zoom to a single panel by adjusting font size directly.
+   * @param {string} panelId - 'left', 'center', or 'right'
+   * @param {number} level - Zoom level
+   */
+  _commitPanelZoom(panelId, level) {
+    const panel = document.getElementById(`panel-${panelId}`);
+    if (!panel) return;
+    const newSize = Math.round(this.baseFontSize * level);
+    const lineH = Math.round(newSize * 1.5);
+    panel.querySelectorAll('.editor-textarea, .line-numbers').forEach(el => {
+      el.style.fontSize = `${newSize}px`;
+      el.style.lineHeight = `${lineH}px`;
+    });
+  }
+
+  /**
+   * Enable or disable synced zoom across all panels.
+   * @param {boolean} enabled
+   */
+  setSyncZoom(enabled) {
+    this.syncZoom = enabled;
+    if (enabled) {
+      // Re-sync all panels to the global level
+      this._panelLevels = { left: this.level, center: this.level, right: this.level };
+      this.commitZoom();
+    }
   }
 
   /** Commit the current zoom level to font-size for crisp text rendering. */


### PR DESCRIPTION
## Summary
- **Close ボタン**: ツールバー + 各パネルヘッダーに配置。保存せずにファイルをクリア（未保存時は確認ダイアログ）。Cmd+W ショートカット対応
- **最近のファイル履歴**: Open ボタン横の ▾ からドロップダウン表示。同セッション中はワンクリックで即座に再オープン。localStorage に永続保存
- **独立パネル操作**: Sync ボタンで Sync/Indep 切り替え。Independent モードでは各パネルが個別にスクロール・ズーム可能

## Changed Files
| File | Change |
|------|--------|
| `index.html` | パネルヘッダーにファイル名・Close ボタン、Recent Files CSS、イベント配線 |
| `js/files.js` | `closeFile()` / `reopenRecent()` / ハンドルキャッシュ / `clearRecentFiles()` |
| `js/ui.js` | Close ボタン、Recent Files ドロップダウン、Sync ラベル切り替え |
| `js/viewport.js` | `syncZoom` / per-panel zoom (`_commitPanelZoom`) / `setSyncZoom()` |
| `js/split-diff.js` | `setSyncScroll()` が `sync:change` イベント発火 |

## Test plan
- [x] Close ボタンでファイルがクリアされることを確認
- [x] 未保存変更時に確認ダイアログが表示されることを確認
- [x] パネルヘッダーの × でそのパネルのみクリアされることを確認
- [x] Recent Files ドロップダウンにファイル履歴が表示されることを確認
- [x] Sync/Indep 切り替えでスクロール同期が ON/OFF されることを確認
- [x] Independent モードで Cmd+スクロールがカーソル下のパネルのみ拡大することを確認

Fixes #5, Fixes #6, Fixes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)